### PR TITLE
feat(login): Attach & execute hooks script in sshd container

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -828,6 +828,15 @@ type SlurmNodeLogin struct {
 	// +kubebuilder:default=0
 	SshdServiceNodePort int32 `json:"sshdServiceNodePort,omitempty"`
 
+	// SshdEntrypointHookScriptPath specifies the path to a custom script that will be executed
+	// before the SSH daemon starts. This hook allows starting additional daemons and services,
+	// as well as extending the login node's initialization with custom setup or configuration.
+	// The script must be accessible within the container and will be executed with bash if not
+	// executable.
+	//
+	// +kubebuilder:validation:Optional
+	SshdEntrypointHookScriptPath string `json:"sshdEntrypointHookScriptPath,omitempty"`
+
 	// Volumes represents the volume configurations for the login node
 	//
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3703,6 +3703,14 @@ spec:
                         description: SSHDConfigMapRefName is the name of the SSHD
                           config, which runs in login container
                         type: string
+                      sshdEntrypointHookScriptPath:
+                        description: |-
+                          SshdEntrypointHookScriptPath specifies the path to a custom script that will be executed
+                          before the SSH daemon starts. This hook allows starting additional daemons and services,
+                          as well as extending the login node's initialization with custom setup or configuration.
+                          The script must be accessible within the container and will be executed with bash if not
+                          executable.
+                        type: string
                       sshdServiceAnnotations:
                         additionalProperties:
                           type: string

--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -226,6 +226,9 @@ spec:
       {{- if eq .Values.slurmNodes.login.sshdServiceType "NodePort" }}
       sshdServiceNodePort: {{ required "slurmNodes.login.sshdServiceNodePort is required in case of slurmNodes.login.sshdServiceType == `NodePort`" .Values.slurmNodes.login.sshdServiceNodePort }}
       {{- end }}
+      {{- if .Values.slurmNodes.login.sshdEntrypointHookScriptPath }}
+      sshdEntrypointHookScriptPath: {{ .Values.slurmNodes.login.sshdEntrypointHookScriptPath | quote }}
+      {{- end }}
       munge:
         image: {{ required "sshd munge" .Values.images.munge | quote }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.slurmNodes.login.munge.imagePullPolicy | quote }}
@@ -239,6 +242,8 @@ spec:
           {{- required ".Values.slurmNodes.login.volumes.jail must be provided." .Values.slurmNodes.login.volumes.jail | toYaml | nindent 10 }}
         jailSubMounts:
           {{- default list .Values.slurmNodes.login.volumes.jailSubMounts | toYaml | nindent 10 }}
+        customMounts:
+          {{- default list .Values.slurmNodes.login.volumes.customMounts | toYaml | nindent 10 }}
     exporter:
       enabled: {{ .Values.slurmNodes.exporter.enabled }}
       size: {{ required ".Values.slurmNodes.exporter.size must be provided." .Values.slurmNodes.exporter.size }}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -348,6 +348,7 @@ slurmNodes:
     sshdServiceNodePort: 30022
     # Annotations to be configure on login service
     sshdServiceAnnotations: {}
+    sshdEntrypointHookScriptPath: ""
     munge:
       imagePullPolicy: "IfNotPresent"
       appArmorProfile: "unconfined"
@@ -363,6 +364,7 @@ slurmNodes:
       #        - name: "mlcommons-sd-bench-data"
       #          mountPath: "/mlperf-sd"
       #          volumeSourceName: "mlperf-sd"
+      customMounts: []
   exporter:
     enabled: true
     size: 1

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -8270,6 +8270,14 @@ spec:
                         description: SSHDConfigMapRefName is the name of the SSHD
                           config, which runs in login container
                         type: string
+                      sshdEntrypointHookScriptPath:
+                        description: |-
+                          SshdEntrypointHookScriptPath specifies the path to a custom script that will be executed
+                          before the SSH daemon starts. This hook allows starting additional daemons and services,
+                          as well as extending the login node's initialization with custom setup or configuration.
+                          The script must be accessible within the container and will be executed with bash if not
+                          executable.
+                        type: string
                       sshdServiceAnnotations:
                         additionalProperties:
                           type: string

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -8270,6 +8270,14 @@ spec:
                         description: SSHDConfigMapRefName is the name of the SSHD
                           config, which runs in login container
                         type: string
+                      sshdEntrypointHookScriptPath:
+                        description: |-
+                          SshdEntrypointHookScriptPath specifies the path to a custom script that will be executed
+                          before the SSH daemon starts. This hook allows starting additional daemons and services,
+                          as well as extending the login node's initialization with custom setup or configuration.
+                          The script must be accessible within the container and will be executed with bash if not
+                          executable.
+                        type: string
                       sshdServiceAnnotations:
                         additionalProperties:
                           type: string

--- a/images/login/sshd_entrypoint.sh
+++ b/images/login/sshd_entrypoint.sh
@@ -40,12 +40,27 @@ echo "Waiting until munge started"
 while [ ! -S "/run/munge/munge.socket.2" ]; do sleep 2; done
 
 # Execute hook script if provided
-if [ -n "${HOOK_SCRIPT}" ] && [ -f "${HOOK_SCRIPT}" ]; then
+if [ -n "${HOOK_SCRIPT}" ]; then
+    # Exit early if the file doesn't exist
+    if [ ! -f "${HOOK_SCRIPT}" ]; then
+        echo "Hook script file '${HOOK_SCRIPT}' does not exist. Exiting."
+        exit 1
+    fi
+
     echo "Executing hook script: ${HOOK_SCRIPT}"
+    set +e
     if [ -x "${HOOK_SCRIPT}" ]; then
         "${HOOK_SCRIPT}"
     else
         bash "${HOOK_SCRIPT}"
+    fi
+
+    exit_code=$?
+    set -e
+
+    if [ $exit_code -ne 0 ]; then
+        echo "Hook script failed with exit code $exit_code. Exiting."
+        exit 1
     fi
 fi
 

--- a/images/login/sshd_entrypoint.sh
+++ b/images/login/sshd_entrypoint.sh
@@ -2,6 +2,20 @@
 
 set -e # Exit immediately if any command returns a non-zero error code
 
+# Parse command line arguments
+HOOK_SCRIPT=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --hook-script)
+            HOOK_SCRIPT="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
 echo "Link users from jail"
 ln -s /mnt/jail/etc/passwd /etc/passwd
 ln -s /mnt/jail/etc/group /etc/group
@@ -24,6 +38,16 @@ echo "Complement jail rootfs"
 # TODO: Since 1.29 kubernetes supports native sidecar containers. We can remove it in feature releases
 echo "Waiting until munge started"
 while [ ! -S "/run/munge/munge.socket.2" ]; do sleep 2; done
+
+# Execute hook script if provided
+if [ -n "${HOOK_SCRIPT}" ] && [ -f "${HOOK_SCRIPT}" ]; then
+    echo "Executing hook script: ${HOOK_SCRIPT}"
+    if [ -x "${HOOK_SCRIPT}" ]; then
+        "${HOOK_SCRIPT}"
+    else
+        bash "${HOOK_SCRIPT}"
+    fi
+fi
 
 echo "Start sshd daemon"
 /usr/sbin/sshd -D -e -f /mnt/ssh-configs/sshd_config

--- a/internal/render/login/container.go
+++ b/internal/render/login/container.go
@@ -15,7 +15,9 @@ import (
 func renderContainerSshd(
 	clusterType consts.ClusterType,
 	container *values.Container,
-	jailSubMounts, customMounts []slurmv1.NodeVolumeMount,
+	jailSubMounts,
+	customMounts []slurmv1.NodeVolumeMount,
+	args []string,
 ) corev1.Container {
 	volumeMounts := []corev1.VolumeMount{
 		common.RenderVolumeMountSlurmConfigs(),
@@ -35,6 +37,7 @@ func renderContainerSshd(
 	return corev1.Container{
 		Name:  consts.ContainerNameSshd,
 		Image: container.Image,
+		Args:  args,
 		Env: []corev1.EnvVar{
 			{
 				Name:  "SLURM_CLUSTER_TYPE",

--- a/internal/render/login/statefulset.go
+++ b/internal/render/login/statefulset.go
@@ -48,6 +48,11 @@ func RenderStatefulSet(
 		replicas = ptr.To(consts.ZeroReplicas)
 	}
 
+	var args []string
+	if login.SSHDEntrypointHookScriptPath != "" {
+		args = append(args, "--hook-script", login.SSHDEntrypointHookScriptPath)
+	}
+
 	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      login.StatefulSet.Name,
@@ -86,7 +91,7 @@ func RenderStatefulSet(
 						common.RenderContainerMunge(&login.ContainerMunge),
 					},
 					Containers: []corev1.Container{
-						renderContainerSshd(clusterType, &login.ContainerSshd, login.JailSubMounts, login.CustomVolumeMounts),
+						renderContainerSshd(clusterType, &login.ContainerSshd, login.JailSubMounts, login.CustomVolumeMounts, args),
 					},
 					Volumes: volumes,
 					DNSConfig: &corev1.PodDNSConfig{

--- a/internal/values/slurm_cluster.go
+++ b/internal/values/slurm_cluster.go
@@ -37,7 +37,7 @@ type SlurmCluster struct {
 	SlurmConfig                   slurmv1.SlurmConfig
 	CustomSlurmConfig             *string
 	MPIConfig                     slurmv1.MPIConfig
-  SlurmTopologyConfigMapRefName string
+	SlurmTopologyConfigMapRefName string
 }
 
 // BuildSlurmClusterFrom creates a new instance of SlurmCluster given a SlurmCluster CRD
@@ -73,13 +73,13 @@ func BuildSlurmClusterFrom(ctx context.Context, cluster *slurmv1.SlurmCluster) (
 			&cluster.Spec.NCCLSettings,
 			cluster.Spec.UseDefaultAppArmorProfile,
 		),
-    NodeLogin:                     buildSlurmLoginFrom(cluster.Name, cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Login, cluster.Spec.UseDefaultAppArmorProfile),
+		NodeLogin:                     buildSlurmLoginFrom(cluster.Name, cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Login, cluster.Spec.UseDefaultAppArmorProfile),
 		Telemetry:                     cluster.Spec.Telemetry,
 		SlurmExporter:                 buildSlurmExporterFrom(cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Exporter),
 		SlurmConfig:                   cluster.Spec.SlurmConfig,
 		CustomSlurmConfig:             cluster.Spec.CustomSlurmConfig,
 		MPIConfig:                     cluster.Spec.MPIConfig,
-    SlurmTopologyConfigMapRefName: cluster.Spec.SlurmTopologyConfigMapRefName,
+		SlurmTopologyConfigMapRefName: cluster.Spec.SlurmTopologyConfigMapRefName,
 	}
 
 	if err := res.Validate(ctx); err != nil {

--- a/internal/values/slurm_login.go
+++ b/internal/values/slurm_login.go
@@ -16,9 +16,10 @@ type SlurmLogin struct {
 	Service     Service
 	StatefulSet StatefulSet
 
-	IsSSHDConfigMapDefault bool
-	SSHDConfigMapName      string
-	SSHRootPublicKeys      []string
+	IsSSHDConfigMapDefault       bool
+	SSHDConfigMapName            string
+	SSHRootPublicKeys            []string
+	SSHDEntrypointHookScriptPath string
 
 	VolumeJail         slurmv1.NodeVolume
 	JailSubMounts      []slurmv1.NodeVolumeMount
@@ -56,12 +57,13 @@ func buildSlurmLoginFrom(clusterName string, maintenance *consts.MaintenanceMode
 			naming.BuildStatefulSetName(consts.ComponentTypeLogin, clusterName),
 			login.SlurmNode.Size,
 		),
-		SSHDConfigMapName:         sshdConfigMapName,
-		IsSSHDConfigMapDefault:    isSSHDConfigDefault,
-		SSHRootPublicKeys:         login.SshRootPublicKeys,
-		VolumeJail:                *login.Volumes.Jail.DeepCopy(),
-		UseDefaultAppArmorProfile: useDefaultAppArmorProfile,
-		Maintenance:               maintenance,
+		SSHDConfigMapName:            sshdConfigMapName,
+		SSHDEntrypointHookScriptPath: login.SshdEntrypointHookScriptPath,
+		IsSSHDConfigMapDefault:       isSSHDConfigDefault,
+		SSHRootPublicKeys:            login.SshRootPublicKeys,
+		VolumeJail:                   *login.Volumes.Jail.DeepCopy(),
+		UseDefaultAppArmorProfile:    useDefaultAppArmorProfile,
+		Maintenance:                  maintenance,
 	}
 	for _, jailSubMount := range login.Volumes.JailSubMounts {
 		subMount := *jailSubMount.DeepCopy()


### PR DESCRIPTION
### Background
For the project I am working on, we need to start additional SSHD server as daemon to cover our login/authentication use cases. The current implementation doesn't provide a way to extend the initialization process.

### Solution
Added a way to extend sshd initialization with custom hook scripts. Users can now specify a path to `.sh` script file (mounted) that will run before sshd starts, enabling custom setup and additional daemons.

Changes:
- Added --hook-script flag to entrypoint
- Added hook script path to login CRD spec (sshdEntrypointHookScriptPath)
- Updated statefulset to pass hook script arg